### PR TITLE
docs: Make inline <script> refer to correct path relative to the built site

### DIFF
--- a/docs/manual/quick-start.md
+++ b/docs/manual/quick-start.md
@@ -45,7 +45,7 @@ Below is a demonstration of the process above:
 
 <script>
 window.onload = () => {
-    let filename = 'assets/quick-start_run.cast';
+    let filename = '../assets/quick-start_run.cast';
     let element_id = 'demo';
     let options = {
         speed: 2,


### PR DESCRIPTION
Make inline HTML element reference point to the correct path relative to the built site.