### PR TITLE
fix: non-wildcard-filenames created at download start are now deleted at download fail.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ab
-version = 0.4.0
+version = 0.4.1
 description = AutoBernese
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8

--- a/tests/ab/test_package.py
+++ b/tests/ab/test_package.py
@@ -3,7 +3,7 @@ from ab import pkg
 
 
 def test_version():
-    assert __version__ == "0.4.0"
+    assert __version__ == "0.4.1"
 
 
 def test_package_data_exist():


### PR DESCRIPTION
The FTP download module only checks ahead if files exists, when the remote filepath has an asterisk in the filename, and so non-wildcard filenames must fail at the download process. Because the local filepath is opened for writing, before anything is downloaded, the file is thus created, even though the download may fail due to a file-not-found error. In addition, when the download error is met and the download status has one added to the fail count, the code is missing a `continue` statement which in turn lets the same download status add one to the number of downloads as well, causing additional confusion.

This change fixes both these issues by

* Deleting any local file that failed to be downloaded. (Adding more logging messages to make this clear.
* Making a failed download cause the program to go on to the next item in the files to download (avoiding the double counting in the download status instance).