### PR TITLE
Make sure that `core.yaml` is installed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ ab =
    bsw/campaign_header.yaml
    bsw/MENU_CMP.INP
    bsw/templates/default.yaml
-   configuration/env.yaml
+   configuration/core.yaml
    configuration/bsw_env_vars
    country_code/ISO-3166-1-alpha-3.yaml
    station/1.03.STA


### PR DESCRIPTION
The file was renamed in 61083bb but unfortunately the setup script wasn't adjusted correspondingly. This commit takes care of that.