### PR TITLE
`ab tr`: wait longer before timing out

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ab
-version = 1.0.0
+version = 1.0.1
 description = AutoBernese
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8

--- a/src/ab/cli/troposphere.py
+++ b/src/ab/cli/troposphere.py
@@ -171,7 +171,7 @@ def build(
 
     """
     args = parse_args(ipath, opath, gps_week, beg, end, ifname, ofname)
-    dispatch(args, "build", "Build", timeout=10)
+    dispatch(args, "build", "Build", timeout=60)
 
 
 @troposphere.command
@@ -190,7 +190,7 @@ def check(
 
     """
     args = parse_args(ipath, opath, gps_week, beg, end, ifname, ofname)
-    dispatch(args, "check", "Check", timeout=10)
+    dispatch(args, "check", "Check", timeout=30)
 
 
 @troposphere.command


### PR DESCRIPTION
When running `ab troposphere build` on files located on a network mounted folder it may be a bit sluggish. From experience 10 s is not always enough, so changed to 60 s for the build command and 30 s for the check command. This should be enough.