### PR TITLE
version 1.0.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ab
-version = 1.0.1
+version = 1.0.2
 description = AutoBernese
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8


### PR DESCRIPTION
CLI: ab station sitelogs2sta command changes

- CLI-provided arguments take precedence over config file settings
- skip_period argument in CLI or YAML (firmware changes have at most skip_period = day)

STA-file generation

- Support for TYPE003 rows
- Support for non-zero azimuth values
- Updated documentation for ab station sitelog2sta
- type_calibrated affects receiver_no as well as antenna_no

Sitelog Parsing (sitelog2sta)

- Improved parsing of antenna and receiver serial numbers when values are missing or default
- Template defaults are now replaced correctly
- Azimuth parsing added
- Empty entries in regex patterns are now supported
- Add tests for sitelog serial number parsing

Maintenance

- Code formatted with Black 26.3.1